### PR TITLE
Extend CAWL 2026 deadline to Feb. 23

### DIFF
--- a/workshops/cawl2026/index.html
+++ b/workshops/cawl2026/index.html
@@ -61,7 +61,7 @@ Palma, Mallorca (Spain), May 12, 2026
 
 <p><strong>Important dates (all deadlines anywhere in the world):</strong></p>
 
-<p>Paper submission deadline: <b>February 20, 2026</b><br />
+<p>Paper submission deadline: <b>February 23, 2026</b> (extended from February 20)<br />
 Notification of acceptance: <b>March 17, 2026</b><br />
 Camera-ready paper due: <b>March 30, 2026</b><br />
 Workshop date: <b>May 12, 2026</b></p>
@@ -70,7 +70,7 @@ Workshop date: <b>May 12, 2026</b></p>
 
 <p>Please submit short (4 page) or long (8 page) submissions in PDF format. Both short and long paper submissions will be reviewed in the same process. Authors should follow the formatting guidelines of LREC 2026, available in <a href="https://lrec2026.info/authors-kit/" target="_blank">the authors’ kit</a>. Note that, as with the main conference, reviewing is double-anonymous, i.e., reviewers will not know author identity and vice versa, hence no author information should be included in the papers; self-reference that identifies the authors should be avoided or anonymised. Accepted papers will appear in the workshop proceedings in the ACL anthology.</p>
 
-<p>Submissions will be accepted at <a href="https://softconf.com/lrec2026/CAWL/" target="_blank">the workshop SoftConf site</a> between now and February 20, 2026.</p>
+<p>Submissions will be accepted at <a href="https://softconf.com/lrec2026/CAWL/" target="_blank">the workshop SoftConf site</a> between now and February 23, 2026.</p>
 
 <p>For questions about the submission guidelines, please contact workshop organizers at <a href="mailto:cawl-2026-organizers@googlegroups.com">cawl-2026-organizers@googlegroups.com</a>.</p>
 


### PR DESCRIPTION
Extends the deadline.