### PR TITLE
Add room names and non-archival paper link

### DIFF
--- a/workshops/cawl2026/index.html
+++ b/workshops/cawl2026/index.html
@@ -39,7 +39,7 @@ Palma, Mallorca (Spain), May 12, 2026
 
 <p>For questions about the workshop, please contact the workshop organizers at <tt><a href="mailto:cawl-2026-organizers@googlegroups.com">cawl-2026-organizers@googlegroups.com</a></tt></p>
 
-<p><b>Schedule</b> (Room 8):</p>
+<p><b>Schedule (all talks in Cabrera 1, 2nd Floor):</b></p>
 <table cellspacing="0" cellpadding="5" border="0"><tr><td valign=top>9:00–9:30</td><td valign=top><strong>Opening remarks</strong><br>Kyle Gorman and Constantine Lignos</td></tr>
     <tr><td valign=top width=100>9:30–10:30</td><td valign=top><strong>Keynote:</strong> <a href="pdf/handel.pdf"><em>Everything you wanted to know about East Asian writing but didn’t think to ask: The history and structure of scripts for Chinese, Japanese, Korean, and Vietnamese</em></a><br>Zev Handel</td></tr>
     <tr><td valign=top width=100><strong>10:30-11:00</strong></td><td valign=top align=left><strong>Coffee break</strong></td></tr>
@@ -52,7 +52,7 @@ Palma, Mallorca (Spain), May 12, 2026
     Joshua Wieler, Simon Petitjean, Kristian Berg, Henriette Huber and Stefan Hartmann</td></tr>
     <tr><td valign=top width=100>11:45–12:00</td><td valign=top align=left><a href="pdf/2006.cawl-1.4.pdf"><i>SoriGraph: A New Database of Visual Feature-Level Descriptions of Written Korean</i></a><br>
     Wednesday Bushong, Hala Habahbeh, Ryan Jiang and Yoolim Kim</td></tr>
-    <tr><td valign=top width=100><strong>12:00–13:00</strong></td><td valign=top align=left><strong>Poster session:</strong></td></td>
+    <tr><td valign=top width=100><strong>12:00–13:00</strong></td><td valign=top align=left><strong>Poster session (Menorca Hall, 3rd floor):</strong></td></td>
     <tr><td></td><td valign=top align=left><a href="pdf/2006.cawl-1.5.pdf"><i>Confusable Characters as Endangered Language Markers: The Case of North Caucasus Writing Systems</i></a><br>
     Alexander Gutkin, Adrian Benton, Christo Kirov and Brian Roark</td></tr>
     <tr><td></td><td valign=top align=left><a href="pdf/2006.cawl-1.6.pdf"><i>Prompting Approaches to Abbreviation Expansion</i></a><br>
@@ -67,7 +67,7 @@ Palma, Mallorca (Spain), May 12, 2026
     Tjaša Šoltes and Marko Bajec</td></tr>
     <tr><td></td><td valign=top align=left><a href="pdf/2006.cawl-1.11.pdf"><i>Inverse Text Normalization for Arabic Numbers in Streaming ASR</i></a><br>
     Enas Albasiri, Myungjong Kim, Nourchene Ferchichi and Oluwatobi Olabiyi</td></tr>
-    <tr><td></td><td valign=top align=left><i>1,729 vs. १७२९: The Effect of Scripts and Formats on LLM Numeracy</i><br>
+    <tr><td></td><td valign=top align=left><a href="https://arxiv.org/pdf/2601.15251"><i>1,729 vs. १७२९: The Effect of Scripts and Formats on LLM Numeracy</i></a> (non-archival)<br>
     Varshini Reddy, Craig W. Schmidt, Seth Ebner, Adam Wiemerslage, Yuval Pinter and Chris Tanner</td></tr>
 </table><br>
 


### PR DESCRIPTION
The formatting of this isn't perfect, but it's the best I could do in the current structure. All talks are in one room; the poster session is in another.